### PR TITLE
chore: enhance CI with coverage, caching, concurrency, and build-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
-    name: "Python ${{ matrix.python-version }}"
+    name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -22,17 +26,90 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
-      - name: Install package and dev dependencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Lint with ruff
+      - name: Run tests with coverage
+        run: |
+          pytest tests/ -v --tb=short \
+            --cov=src \
+            --cov-report=xml \
+            --cov-report=term-missing \
+            --cov-fail-under=70
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          flags: unittests
+          fail_ci_if_error: false
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install ruff
+        run: pip install "ruff>=0.4.0"
+
+      - name: Run ruff check
         run: ruff check src/ tests/
 
-      - name: Type check with mypy
-        run: mypy src/regulated_ai_governance/ --ignore-missing-imports
+      - name: Run ruff format check
+        run: ruff format --check src/ tests/
 
-      - name: Run tests
-        run: pytest tests/ -v --tb=short
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run mypy
+        run: mypy src/
+
+  build-check:
+    name: Build Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Check distribution
+        run: twine check dist/*
+
+      - name: Verify installable
+        run: pip install dist/*.whl --force-reinstall

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ semantic-kernel = ["semantic-kernel>=1.0.0"]
 haystack = ["haystack-ai>=2.0.0"]
 dev = [
     "pytest>=8.0",
-    "pytest-cov",
+    "pytest-cov>=4.0",
     "ruff>=0.4",
     "mypy>=1.9",
 ]

--- a/src/regulated_ai_governance/agent_guard.py
+++ b/src/regulated_ai_governance/agent_guard.py
@@ -155,9 +155,7 @@ class GovernedActionGuard:
             action_name=action_name,
             permitted=decision.permitted,
             denial_reason=decision.denial_reason,
-            escalation_target=(
-                decision.escalation.escalate_to if decision.escalation else None
-            ),
+            escalation_target=(decision.escalation.escalate_to if decision.escalation else None),
             context=context or {},
             policy_version=self._policy_version,
         )
@@ -190,13 +188,9 @@ class GovernedActionGuard:
         self._emit_audit(action_name, decision, context)
 
         if not decision.permitted:
-            message = (
-                f"[regulated-ai-governance] Action BLOCKED — {decision.denial_reason}"
-            )
+            message = f"[regulated-ai-governance] Action BLOCKED — {decision.denial_reason}"
             if decision.escalation:
-                message += (
-                    f" | Escalation target: {decision.escalation.escalate_to}"
-                )
+                message += f" | Escalation target: {decision.escalation.escalate_to}"
             if self._raise_on_deny:
                 raise PermissionError(message)
             return message

--- a/src/regulated_ai_governance/integrations/crewai.py
+++ b/src/regulated_ai_governance/integrations/crewai.py
@@ -43,8 +43,7 @@ try:
     from pydantic import PrivateAttr
 except ImportError as exc:
     raise ImportError(
-        "crewai is required for this integration. "
-        "Install it with: pip install regulated-ai-governance[crewai]"
+        "crewai is required for this integration. Install it with: pip install regulated-ai-governance[crewai]"
     ) from exc
 
 from regulated_ai_governance.agent_guard import GovernedActionGuard

--- a/src/regulated_ai_governance/integrations/langchain.py
+++ b/src/regulated_ai_governance/integrations/langchain.py
@@ -111,7 +111,8 @@ class FERPAComplianceCallbackHandler(BaseCallbackHandler):
     def _apply_identity_filter(self, documents: list[Document]) -> list[Document]:
         """Layer 1: filter by student_id + institution_id."""
         return [
-            doc for doc in documents
+            doc
+            for doc in documents
             if (
                 doc.metadata.get(self.student_id_field) == self.student_id
                 and doc.metadata.get(self.institution_id_field) == self.institution_id
@@ -122,10 +123,7 @@ class FERPAComplianceCallbackHandler(BaseCallbackHandler):
         """Layer 2: filter by allowed_categories."""
         if not self.allowed_categories:
             return documents
-        return [
-            doc for doc in documents
-            if doc.metadata.get(self.category_field) in self.allowed_categories
-        ]
+        return [doc for doc in documents if doc.metadata.get(self.category_field) in self.allowed_categories]
 
     def on_retriever_end(
         self,
@@ -170,11 +168,7 @@ class FERPAComplianceCallbackHandler(BaseCallbackHandler):
                     "parent_run_id": str(parent_run_id) if parent_run_id else None,
                     "student_id": self.student_id,
                     "institution_id": self.institution_id,
-                    "allowed_categories": (
-                        sorted(self.allowed_categories)
-                        if self.allowed_categories
-                        else None
-                    ),
+                    "allowed_categories": (sorted(self.allowed_categories) if self.allowed_categories else None),
                 },
             )
             self.audit_sink(record)

--- a/src/regulated_ai_governance/policy.py
+++ b/src/regulated_ai_governance/policy.py
@@ -90,15 +90,12 @@ class ActionPolicy:
         if self.allowed_actions and self.require_all_allowed:
             if action_name not in self.allowed_actions:
                 return False, (
-                    f"Action '{action_name}' is not in the allowed actions set. "
-                    f"Allowed: {sorted(self.allowed_actions)}"
+                    f"Action '{action_name}' is not in the allowed actions set. Allowed: {sorted(self.allowed_actions)}"
                 )
 
         return True, ""
 
-    def escalation_for(
-        self, action_name: str, context: dict | None = None
-    ) -> EscalationRule | None:
+    def escalation_for(self, action_name: str, context: dict | None = None) -> EscalationRule | None:
         """
         Return the first ``EscalationRule`` that matches *action_name*, or None.
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -22,19 +22,13 @@ class TestGovernanceAuditRecord:
         assert record.permitted is True
 
     def test_record_id_is_auto_generated_uuid(self):
-        r1 = GovernanceAuditRecord(
-            regulation="FERPA", actor_id="a", action_name="x", permitted=True
-        )
-        r2 = GovernanceAuditRecord(
-            regulation="FERPA", actor_id="a", action_name="x", permitted=True
-        )
+        r1 = GovernanceAuditRecord(regulation="FERPA", actor_id="a", action_name="x", permitted=True)
+        r2 = GovernanceAuditRecord(regulation="FERPA", actor_id="a", action_name="x", permitted=True)
         assert r1.record_id != r2.record_id
         assert len(r1.record_id) == 36  # UUID4 format
 
     def test_timestamp_is_utc(self):
-        record = GovernanceAuditRecord(
-            regulation="HIPAA", actor_id="emp-001", action_name="read_phi", permitted=False
-        )
+        record = GovernanceAuditRecord(regulation="HIPAA", actor_id="emp-001", action_name="read_phi", permitted=False)
         assert record.timestamp.tzinfo == timezone.utc
 
     def test_to_log_entry_is_json_serializable(self):

--- a/tests/test_regulations.py
+++ b/tests/test_regulations.py
@@ -93,9 +93,7 @@ class TestHIPAATreatingProviderPolicy:
         assert permitted is False
 
     def test_escalates_external_share(self):
-        policy = make_hipaa_treating_provider_policy(
-            escalate_external_share_to="hipaa_privacy_officer"
-        )
+        policy = make_hipaa_treating_provider_policy(escalate_external_share_to="hipaa_privacy_officer")
         result = policy.escalation_for("share_records_externally", {})
         assert result is not None
         assert result.escalate_to == "hipaa_privacy_officer"
@@ -126,16 +124,12 @@ class TestHIPAAResearcherPolicy:
         assert permitted is True
 
     def test_denies_phi_export(self):
-        policy = make_hipaa_researcher_policy(
-            irb_approved_categories={"read_lab_results"}
-        )
+        policy = make_hipaa_researcher_policy(irb_approved_categories={"read_lab_results"})
         permitted, _ = policy.permits("export_phi")
         assert permitted is False
 
     def test_denies_clinical_note_creation(self):
-        policy = make_hipaa_researcher_policy(
-            irb_approved_categories={"read_lab_results"}
-        )
+        policy = make_hipaa_researcher_policy(irb_approved_categories={"read_lab_results"})
         permitted, _ = policy.permits("create_clinical_note")
         assert permitted is False
 


### PR DESCRIPTION
## Summary

- Adds `concurrency` block to cancel in-progress runs on the same ref
- Enables `pip` caching via `actions/setup-python@v5` `cache: "pip"` parameter
- Splits the monolithic test job (which previously ran lint + typecheck + tests in one step) into four separate jobs: `test`, `lint`, `typecheck`, `build-check`
- Adds coverage-instrumented pytest run (`--cov=src`, `--cov-report=xml`, `--cov-fail-under=70`) with Codecov upload on Python 3.12 leg
- Upgrades lint job: pins `ruff>=0.4.0`, adds `ruff format --check` step
- Typecheck job now targets `mypy src/` (full package, no manual `--ignore-missing-imports` override since `pyproject.toml` already sets it)
- Adds new **Build Check** job: builds sdist+wheel with `build`, validates metadata with `twine check`, smoke-tests wheel install
- Pins `pytest-cov>=4.0` in `[dev]` optional-dependencies (was unpinned)

## Test plan

- [ ] All three matrix test legs pass with coverage >= 70%
- [ ] Lint job passes `ruff check` and `ruff format --check`
- [ ] Type check job passes `mypy src/`
- [ ] Build check job produces a valid distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)