### PR TITLE
feat: add CrewAI, AutoGen, and Semantic Kernel compliance adapters

### DIFF
--- a/src/regulated_ai_governance/adapters/__init__.py
+++ b/src/regulated_ai_governance/adapters/__init__.py
@@ -1,0 +1,11 @@
+"""Framework adapters for regulated-ai-governance."""
+from regulated_ai_governance.adapters.autogen import PolicyEnforcingAgent
+from regulated_ai_governance.adapters.crewai import EnterpriseActionGuard, PolicyViolationError
+from regulated_ai_governance.adapters.semantic_kernel import PolicyKernelPlugin
+
+__all__ = [
+    "EnterpriseActionGuard",
+    "PolicyViolationError",
+    "PolicyEnforcingAgent",
+    "PolicyKernelPlugin",
+]

--- a/src/regulated_ai_governance/adapters/__init__.py
+++ b/src/regulated_ai_governance/adapters/__init__.py
@@ -1,4 +1,5 @@
 """Framework adapters for regulated-ai-governance."""
+
 from regulated_ai_governance.adapters.autogen import PolicyEnforcingAgent
 from regulated_ai_governance.adapters.crewai import EnterpriseActionGuard, PolicyViolationError
 from regulated_ai_governance.adapters.semantic_kernel import PolicyKernelPlugin

--- a/src/regulated_ai_governance/adapters/autogen.py
+++ b/src/regulated_ai_governance/adapters/autogen.py
@@ -1,0 +1,112 @@
+"""
+AutoGen adapter for regulated-ai-governance.
+
+Provides PolicyEnforcingAgent — wraps AutoGen ConversableAgent to check
+CompliancePolicy before generating replies involving regulated data.
+
+Regulatory basis: FERPA 34 CFR § 99.3, HIPAA 45 CFR § 164.514
+
+Usage:
+    from regulated_ai_governance.adapters.autogen import PolicyEnforcingAgent
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _import_autogen() -> Any:
+    for pkg in ("autogen", "pyautogen", "autogen_agentchat"):
+        try:
+            import importlib
+
+            return importlib.import_module(pkg)
+        except ImportError:
+            continue
+    raise ImportError(
+        "autogen or pyautogen is required for this integration. "
+        "Install with: pip install 'regulated-ai-governance[autogen]'"
+    )
+
+
+class PolicyEnforcingAgent:
+    """
+    Duck-typed AutoGen ConversableAgent wrapper that checks policy before
+    generating replies.
+
+    In regulated environments, every agent reply involving PHI/FERPA records
+    must be gated by access policy. This wrapper intercepts generate_reply
+    and blocks responses that would violate configured policy.
+
+    Args:
+        agent: The underlying AutoGen ConversableAgent (duck-typed)
+        policy: ActionPolicy or CompliancePolicy defining permitted actions
+        blocked_reply: Message to send when policy blocks a reply
+        regulation_citation: Regulatory basis string for audit logs
+    """
+
+    def __init__(
+        self,
+        agent: Any,
+        policy: Any,
+        blocked_reply: str = "[Response blocked by compliance policy]",
+        regulation_citation: str = "FERPA 34 CFR § 99.3",
+    ) -> None:
+        _import_autogen()
+        self._agent = agent
+        self._policy = policy
+        self._blocked_reply = blocked_reply
+        self._regulation_citation = regulation_citation
+        # Mirror agent attributes
+        self.name: str = getattr(agent, "name", "policy-enforcing-agent")
+
+    def _is_permitted(self) -> bool:
+        """Check policy using can_run or permits, handling both interfaces."""
+        if hasattr(self._policy, "can_run"):
+            return bool(self._policy.can_run(self.name))
+        if hasattr(self._policy, "permits"):
+            permitted, _ = self._policy.permits(self.name)
+            return permitted
+        return True
+
+    def generate_reply(
+        self,
+        messages: list[dict[str, Any]] | None = None,
+        sender: Any = None,
+        **kwargs: Any,
+    ) -> str | dict[str, Any] | None:
+        """
+        Generate a reply only if policy permits.
+
+        Checks whether the agent's name (which represents its role/action scope)
+        is permitted by the configured policy. If not, returns the blocked_reply
+        message and emits a warning audit log.
+        """
+        permitted = self._is_permitted()
+
+        logger.info(
+            "autogen_policy_check | agent=%r | permitted=%s | regulation=%s",
+            self.name,
+            permitted,
+            self._regulation_citation,
+        )
+
+        if not permitted:
+            logger.warning(
+                "autogen_policy_blocked | agent=%r | regulation=%s",
+                self.name,
+                self._regulation_citation,
+            )
+            return self._blocked_reply
+
+        return self._agent.generate_reply(messages=messages, sender=sender, **kwargs)
+
+    def initiate_chat(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to underlying agent."""
+        return self._agent.initiate_chat(*args, **kwargs)
+
+    def receive(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to underlying agent."""
+        return self._agent.receive(*args, **kwargs)

--- a/src/regulated_ai_governance/adapters/autogen.py
+++ b/src/regulated_ai_governance/adapters/autogen.py
@@ -9,6 +9,7 @@ Regulatory basis: FERPA 34 CFR § 99.3, HIPAA 45 CFR § 164.514
 Usage:
     from regulated_ai_governance.adapters.autogen import PolicyEnforcingAgent
 """
+
 from __future__ import annotations
 
 import logging

--- a/src/regulated_ai_governance/adapters/crewai.py
+++ b/src/regulated_ai_governance/adapters/crewai.py
@@ -12,6 +12,7 @@ Usage:
     # Wrap any CrewAI tool
     guarded = EnterpriseActionGuard(tool=my_tool, policy=action_policy)
 """
+
 from __future__ import annotations
 
 import logging
@@ -47,8 +48,7 @@ def _import_crewai() -> Any:
         return crewai
     except ImportError as exc:
         raise ImportError(
-            "crewai is required for this integration. "
-            "Install with: pip install 'regulated-ai-governance[crewai]'"
+            "crewai is required for this integration. Install with: pip install 'regulated-ai-governance[crewai]'"
         ) from exc
 
 

--- a/src/regulated_ai_governance/adapters/crewai.py
+++ b/src/regulated_ai_governance/adapters/crewai.py
@@ -1,0 +1,134 @@
+"""
+CrewAI adapter for regulated-ai-governance.
+
+Provides EnterpriseActionGuard — a CrewAI BaseTool wrapper that enforces
+ActionPolicy before any tool execution. Use this to prevent CrewAI agents
+from running tools outside their authorized policy boundary.
+
+Regulatory basis: FERPA 34 CFR § 99.31(a)(1), HIPAA 45 CFR § 164.308(a)(4)
+
+Usage:
+    from regulated_ai_governance.adapters.crewai import EnterpriseActionGuard
+    # Wrap any CrewAI tool
+    guarded = EnterpriseActionGuard(tool=my_tool, policy=action_policy)
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class PolicyViolationError(Exception):
+    """Raised when an agent attempts an action blocked by policy."""
+
+    action: str
+    policy_name: str
+    regulation_citation: str = "FERPA 34 CFR § 99.31(a)(1)"
+
+    def __str__(self) -> str:
+        return (
+            f"Policy violation: action '{self.action}' is not permitted under "
+            f"policy '{self.policy_name}'. "
+            f"Regulatory basis: {self.regulation_citation}"
+        )
+
+
+def _import_crewai() -> Any:
+    try:
+        import crewai  # noqa: F401
+
+        return crewai
+    except ImportError as exc:
+        raise ImportError(
+            "crewai is required for this integration. "
+            "Install with: pip install 'regulated-ai-governance[crewai]'"
+        ) from exc
+
+
+class EnterpriseActionGuard:
+    """
+    Wraps a CrewAI tool with enterprise policy enforcement.
+
+    Checks ActionPolicy.can_run(tool_name) before delegating to the
+    underlying tool. If the action is not permitted, raises PolicyViolationError
+    and emits a structured audit log entry.
+
+    Duck-typed to CrewAI BaseTool interface — no hard import at class definition.
+
+    Args:
+        tool: The CrewAI tool to guard (duck-typed, must have .name and ._run())
+        policy: ActionPolicy defining which actions are permitted
+        regulation_citation: Regulatory basis for the policy (default: FERPA)
+        policy_name: Human-readable name for this policy (for audit logs)
+    """
+
+    def __init__(
+        self,
+        tool: Any,
+        policy: Any,  # regulated_ai_governance.policy.ActionPolicy
+        regulation_citation: str = "FERPA 34 CFR § 99.31(a)(1)",
+        policy_name: str = "enterprise-action-policy",
+    ) -> None:
+        _import_crewai()
+        self._tool = tool
+        self._policy = policy
+        self._regulation_citation = regulation_citation
+        self._policy_name = policy_name
+        # Mirror CrewAI tool attributes
+        self.name: str = getattr(tool, "name", "unknown_tool")
+        self.description: str = getattr(tool, "description", "")
+
+    def _can_run(self, action_name: str) -> bool:
+        """
+        Delegate to policy.can_run if available; otherwise use policy.permits.
+
+        ActionPolicy in this library uses permits(), which returns (bool, str).
+        """
+        if hasattr(self._policy, "can_run"):
+            return bool(self._policy.can_run(action_name))
+        if hasattr(self._policy, "permits"):
+            permitted, _ = self._policy.permits(action_name)
+            return permitted
+        # Permissive fallback — should not occur in normal usage
+        return True
+
+    def _run(self, *args: Any, **kwargs: Any) -> Any:
+        """
+        Execute tool if permitted by policy; raise PolicyViolationError otherwise.
+
+        Audit log emitted on every call (permitted or denied) per regulated
+        AI governance requirements.
+        """
+        permitted = self._can_run(self.name)
+
+        if permitted:
+            logger.info(
+                "policy_check | action=%r | permitted=True | policy=%r | regulation=%s",
+                self.name,
+                self._policy_name,
+                self._regulation_citation,
+            )
+            return self._tool._run(*args, **kwargs)
+        else:
+            logger.warning(
+                "policy_check | action=%r | permitted=False | policy=%r | regulation=%s",
+                self.name,
+                self._policy_name,
+                self._regulation_citation,
+            )
+            raise PolicyViolationError(
+                action=self.name,
+                policy_name=self._policy_name,
+                regulation_citation=self._regulation_citation,
+            )
+
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        """Public CrewAI interface (delegates to _run)."""
+        return self._run(*args, **kwargs)

--- a/src/regulated_ai_governance/adapters/semantic_kernel.py
+++ b/src/regulated_ai_governance/adapters/semantic_kernel.py
@@ -1,0 +1,95 @@
+"""
+Semantic Kernel adapter for regulated-ai-governance.
+
+Provides PolicyKernelPlugin — an SK plugin that exposes policy check as
+a native SK function, enabling policy enforcement within SK pipelines.
+
+Regulatory basis: FERPA 34 CFR § 99.31, HIPAA 45 CFR § 164.308
+
+Usage:
+    from regulated_ai_governance.adapters.semantic_kernel import PolicyKernelPlugin
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _import_semantic_kernel() -> Any:
+    try:
+        import semantic_kernel  # noqa: F401
+
+        return semantic_kernel
+    except ImportError as exc:
+        raise ImportError(
+            "semantic-kernel is required for this integration. "
+            "Install with: pip install 'regulated-ai-governance[semantic-kernel]'"
+        ) from exc
+
+
+class PolicyKernelPlugin:
+    """
+    Semantic Kernel plugin that exposes policy enforcement as SK functions.
+
+    Adds two SK-callable functions:
+    - check_action_permitted(action_name): returns bool
+    - get_permitted_actions(): returns list of permitted action names
+
+    Duck-typed — does not inherit from SK base class at definition time.
+    Register with kernel.add_plugin(PolicyKernelPlugin(...), plugin_name="policy")
+
+    Args:
+        policy: ActionPolicy defining which actions are permitted
+        regulation_citation: Regulatory basis string for audit logs
+    """
+
+    def __init__(
+        self,
+        policy: Any,
+        regulation_citation: str = "FERPA 34 CFR § 99.31(a)(1)",
+    ) -> None:
+        _import_semantic_kernel()
+        self._policy = policy
+        self._regulation_citation = regulation_citation
+
+    def _is_permitted(self, action_name: str) -> bool:
+        """Delegate to policy using can_run or permits, handling both interfaces."""
+        if hasattr(self._policy, "can_run"):
+            return bool(self._policy.can_run(action_name))
+        if hasattr(self._policy, "permits"):
+            permitted, _ = self._policy.permits(action_name)
+            return permitted
+        return True
+
+    def check_action_permitted(self, action_name: str) -> bool:
+        """
+        SK-callable function: check if action_name is permitted by policy.
+
+        Args:
+            action_name: Name of the action/tool to check
+
+        Returns:
+            True if permitted, False otherwise
+        """
+        permitted = self._is_permitted(action_name)
+
+        logger.info(
+            "sk_policy_check | action=%r | permitted=%s | regulation=%s",
+            action_name,
+            permitted,
+            self._regulation_citation,
+        )
+        return permitted
+
+    def get_permitted_actions(self) -> list[str]:
+        """
+        SK-callable function: return list of all permitted action names.
+
+        Returns:
+            List of action names that policy allows
+        """
+        if hasattr(self._policy, "allowed_actions"):
+            return sorted(self._policy.allowed_actions)
+        return []

--- a/src/regulated_ai_governance/adapters/semantic_kernel.py
+++ b/src/regulated_ai_governance/adapters/semantic_kernel.py
@@ -9,6 +9,7 @@ Regulatory basis: FERPA 34 CFR § 99.31, HIPAA 45 CFR § 164.308
 Usage:
     from regulated_ai_governance.adapters.semantic_kernel import PolicyKernelPlugin
 """
+
 from __future__ import annotations
 
 import logging

--- a/src/regulated_ai_governance/agent_guard.py
+++ b/src/regulated_ai_governance/agent_guard.py
@@ -155,9 +155,7 @@ class GovernedActionGuard:
             action_name=action_name,
             permitted=decision.permitted,
             denial_reason=decision.denial_reason,
-            escalation_target=(
-                decision.escalation.escalate_to if decision.escalation else None
-            ),
+            escalation_target=(decision.escalation.escalate_to if decision.escalation else None),
             context=context or {},
             policy_version=self._policy_version,
         )
@@ -190,13 +188,9 @@ class GovernedActionGuard:
         self._emit_audit(action_name, decision, context)
 
         if not decision.permitted:
-            message = (
-                f"[regulated-ai-governance] Action BLOCKED — {decision.denial_reason}"
-            )
+            message = f"[regulated-ai-governance] Action BLOCKED — {decision.denial_reason}"
             if decision.escalation:
-                message += (
-                    f" | Escalation target: {decision.escalation.escalate_to}"
-                )
+                message += f" | Escalation target: {decision.escalation.escalate_to}"
             if self._raise_on_deny:
                 raise PermissionError(message)
             return message

--- a/src/regulated_ai_governance/integrations/crewai.py
+++ b/src/regulated_ai_governance/integrations/crewai.py
@@ -43,8 +43,7 @@ try:
     from pydantic import PrivateAttr
 except ImportError as exc:
     raise ImportError(
-        "crewai is required for this integration. "
-        "Install it with: pip install regulated-ai-governance[crewai]"
+        "crewai is required for this integration. Install it with: pip install regulated-ai-governance[crewai]"
     ) from exc
 
 from regulated_ai_governance.agent_guard import GovernedActionGuard

--- a/src/regulated_ai_governance/integrations/langchain.py
+++ b/src/regulated_ai_governance/integrations/langchain.py
@@ -111,7 +111,8 @@ class FERPAComplianceCallbackHandler(BaseCallbackHandler):
     def _apply_identity_filter(self, documents: list[Document]) -> list[Document]:
         """Layer 1: filter by student_id + institution_id."""
         return [
-            doc for doc in documents
+            doc
+            for doc in documents
             if (
                 doc.metadata.get(self.student_id_field) == self.student_id
                 and doc.metadata.get(self.institution_id_field) == self.institution_id
@@ -122,10 +123,7 @@ class FERPAComplianceCallbackHandler(BaseCallbackHandler):
         """Layer 2: filter by allowed_categories."""
         if not self.allowed_categories:
             return documents
-        return [
-            doc for doc in documents
-            if doc.metadata.get(self.category_field) in self.allowed_categories
-        ]
+        return [doc for doc in documents if doc.metadata.get(self.category_field) in self.allowed_categories]
 
     def on_retriever_end(
         self,
@@ -170,11 +168,7 @@ class FERPAComplianceCallbackHandler(BaseCallbackHandler):
                     "parent_run_id": str(parent_run_id) if parent_run_id else None,
                     "student_id": self.student_id,
                     "institution_id": self.institution_id,
-                    "allowed_categories": (
-                        sorted(self.allowed_categories)
-                        if self.allowed_categories
-                        else None
-                    ),
+                    "allowed_categories": (sorted(self.allowed_categories) if self.allowed_categories else None),
                 },
             )
             self.audit_sink(record)

--- a/src/regulated_ai_governance/policy.py
+++ b/src/regulated_ai_governance/policy.py
@@ -90,15 +90,12 @@ class ActionPolicy:
         if self.allowed_actions and self.require_all_allowed:
             if action_name not in self.allowed_actions:
                 return False, (
-                    f"Action '{action_name}' is not in the allowed actions set. "
-                    f"Allowed: {sorted(self.allowed_actions)}"
+                    f"Action '{action_name}' is not in the allowed actions set. Allowed: {sorted(self.allowed_actions)}"
                 )
 
         return True, ""
 
-    def escalation_for(
-        self, action_name: str, context: dict | None = None
-    ) -> EscalationRule | None:
+    def escalation_for(self, action_name: str, context: dict | None = None) -> EscalationRule | None:
         """
         Return the first ``EscalationRule`` that matches *action_name*, or None.
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -4,6 +4,7 @@ Tests for framework adapters — CrewAI, AutoGen, Semantic Kernel.
 All tests use duck-typed stubs; no real crewai/autogen/semantic-kernel
 imports are required to run the suite.
 """
+
 from __future__ import annotations
 
 import logging
@@ -16,7 +17,6 @@ from regulated_ai_governance.adapters.autogen import PolicyEnforcingAgent
 from regulated_ai_governance.adapters.crewai import EnterpriseActionGuard, PolicyViolationError
 from regulated_ai_governance.adapters.semantic_kernel import PolicyKernelPlugin
 from regulated_ai_governance.policy import ActionPolicy
-
 
 # ---------------------------------------------------------------------------
 # Shared stubs

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,444 @@
+"""
+Tests for framework adapters — CrewAI, AutoGen, Semantic Kernel.
+
+All tests use duck-typed stubs; no real crewai/autogen/semantic-kernel
+imports are required to run the suite.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from regulated_ai_governance.adapters.autogen import PolicyEnforcingAgent
+from regulated_ai_governance.adapters.crewai import EnterpriseActionGuard, PolicyViolationError
+from regulated_ai_governance.adapters.semantic_kernel import PolicyKernelPlugin
+from regulated_ai_governance.policy import ActionPolicy
+
+
+# ---------------------------------------------------------------------------
+# Shared stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubCrewAITool:
+    """Duck-typed stand-in for a CrewAI BaseTool."""
+
+    def __init__(self, name: str, return_value: Any = "tool_result") -> None:
+        self.name = name
+        self.description = f"Stub tool: {name}"
+        self._return_value = return_value
+        self.call_count = 0
+
+    def _run(self, *args: Any, **kwargs: Any) -> Any:
+        self.call_count += 1
+        return self._return_value
+
+
+class _StubAutoGenAgent:
+    """Duck-typed stand-in for an AutoGen ConversableAgent."""
+
+    def __init__(self, name: str, reply: str = "agent_reply") -> None:
+        self.name = name
+        self._reply = reply
+        self.generate_reply_count = 0
+
+    def generate_reply(self, messages: Any = None, sender: Any = None, **kwargs: Any) -> str:
+        self.generate_reply_count += 1
+        return self._reply
+
+    def initiate_chat(self, *args: Any, **kwargs: Any) -> str:
+        return "chat_started"
+
+    def receive(self, *args: Any, **kwargs: Any) -> str:
+        return "received"
+
+
+def _allow_policy(*actions: str) -> ActionPolicy:
+    """Return an ActionPolicy that permits exactly the listed actions."""
+    return ActionPolicy(allowed_actions=set(actions), require_all_allowed=True)
+
+
+def _deny_all_policy() -> ActionPolicy:
+    """Return an ActionPolicy that permits nothing (empty allowed set + require_all)."""
+    return ActionPolicy(allowed_actions=set(), require_all_allowed=True)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: patch framework imports so tests run without SDKs installed
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_framework_imports():
+    """Prevent ImportError when crewai / autogen / semantic-kernel are absent."""
+    with (
+        patch("regulated_ai_governance.adapters.crewai._import_crewai", return_value=MagicMock()),
+        patch("regulated_ai_governance.adapters.autogen._import_autogen", return_value=MagicMock()),
+        patch(
+            "regulated_ai_governance.adapters.semantic_kernel._import_semantic_kernel",
+            return_value=MagicMock(),
+        ),
+    ):
+        yield
+
+
+# ===========================================================================
+# EnterpriseActionGuard (CrewAI adapter)
+# ===========================================================================
+
+
+class TestEnterpriseActionGuard:
+    # -----------------------------------------------------------------------
+    # Core permit / deny behaviour
+    # -----------------------------------------------------------------------
+
+    def test_permitted_action_executes_underlying_tool(self) -> None:
+        tool = _StubCrewAITool("read_transcript")
+        guard = EnterpriseActionGuard(tool=tool, policy=_allow_policy("read_transcript"))
+        result = guard._run()
+        assert result == "tool_result"
+        assert tool.call_count == 1
+
+    def test_blocked_action_raises_policy_violation_error(self) -> None:
+        tool = _StubCrewAITool("export_records")
+        guard = EnterpriseActionGuard(tool=tool, policy=_allow_policy("read_transcript"))
+        with pytest.raises(PolicyViolationError):
+            guard._run()
+
+    def test_blocked_action_does_not_call_underlying_tool(self) -> None:
+        tool = _StubCrewAITool("export_records")
+        guard = EnterpriseActionGuard(tool=tool, policy=_allow_policy("read_transcript"))
+        with pytest.raises(PolicyViolationError):
+            guard._run()
+        assert tool.call_count == 0
+
+    def test_public_run_delegates_to_private_run(self) -> None:
+        tool = _StubCrewAITool("read_transcript")
+        guard = EnterpriseActionGuard(tool=tool, policy=_allow_policy("read_transcript"))
+        assert guard.run() == guard._run.__func__(guard)  # type: ignore[attr-defined]
+
+    def test_run_method_same_result_as__run(self) -> None:
+        tool = _StubCrewAITool("read_transcript", return_value={"data": 42})
+        guard = EnterpriseActionGuard(tool=tool, policy=_allow_policy("read_transcript"))
+        assert guard.run() == {"data": 42}
+
+    # -----------------------------------------------------------------------
+    # PolicyViolationError fields
+    # -----------------------------------------------------------------------
+
+    def test_policy_violation_error_has_correct_action_field(self) -> None:
+        tool = _StubCrewAITool("export_records")
+        guard = EnterpriseActionGuard(
+            tool=tool,
+            policy=_allow_policy("other"),
+            policy_name="test-policy",
+        )
+        with pytest.raises(PolicyViolationError) as exc_info:
+            guard._run()
+        assert exc_info.value.action == "export_records"
+
+    def test_policy_violation_error_has_correct_policy_name(self) -> None:
+        tool = _StubCrewAITool("export_records")
+        guard = EnterpriseActionGuard(
+            tool=tool,
+            policy=_allow_policy("other"),
+            policy_name="my-custom-policy",
+        )
+        with pytest.raises(PolicyViolationError) as exc_info:
+            guard._run()
+        assert exc_info.value.policy_name == "my-custom-policy"
+
+    def test_policy_violation_error_has_regulation_citation(self) -> None:
+        tool = _StubCrewAITool("export_records")
+        guard = EnterpriseActionGuard(
+            tool=tool,
+            policy=_allow_policy("other"),
+            regulation_citation="HIPAA 45 CFR § 164.308(a)(4)",
+        )
+        with pytest.raises(PolicyViolationError) as exc_info:
+            guard._run()
+        assert "HIPAA" in exc_info.value.regulation_citation
+
+    def test_policy_violation_error_str_contains_action_and_policy(self) -> None:
+        err = PolicyViolationError(
+            action="forbidden_action",
+            policy_name="strict-policy",
+            regulation_citation="FERPA 34 CFR § 99.31(a)(1)",
+        )
+        text = str(err)
+        assert "forbidden_action" in text
+        assert "strict-policy" in text
+        assert "FERPA" in text
+
+    # -----------------------------------------------------------------------
+    # Name / description mirroring
+    # -----------------------------------------------------------------------
+
+    def test_guard_mirrors_tool_name(self) -> None:
+        tool = _StubCrewAITool("my_special_tool")
+        guard = EnterpriseActionGuard(tool=tool, policy=_allow_policy("my_special_tool"))
+        assert guard.name == "my_special_tool"
+
+    def test_guard_mirrors_tool_description(self) -> None:
+        tool = _StubCrewAITool("read_transcript")
+        guard = EnterpriseActionGuard(tool=tool, policy=_allow_policy("read_transcript"))
+        assert guard.description == tool.description
+
+    # -----------------------------------------------------------------------
+    # Audit logging
+    # -----------------------------------------------------------------------
+
+    def test_permitted_action_emits_info_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        tool = _StubCrewAITool("read_transcript")
+        guard = EnterpriseActionGuard(tool=tool, policy=_allow_policy("read_transcript"))
+        with caplog.at_level(logging.INFO, logger="regulated_ai_governance.adapters.crewai"):
+            guard._run()
+        assert any("permitted=True" in r.message for r in caplog.records)
+
+    def test_blocked_action_emits_warning_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        tool = _StubCrewAITool("export_records")
+        guard = EnterpriseActionGuard(tool=tool, policy=_allow_policy("read_transcript"))
+        with caplog.at_level(logging.WARNING, logger="regulated_ai_governance.adapters.crewai"):
+            with pytest.raises(PolicyViolationError):
+                guard._run()
+        assert any("permitted=False" in r.message for r in caplog.records)
+
+    # -----------------------------------------------------------------------
+    # Deny-list policy blocks specific actions
+    # -----------------------------------------------------------------------
+
+    def test_explicitly_denied_action_is_blocked(self) -> None:
+        """ActionPolicy with action in denied_actions blocks execution."""
+        policy = ActionPolicy(
+            allowed_actions={"read_transcript"},
+            denied_actions={"read_transcript"},
+            require_all_allowed=True,
+        )
+        tool = _StubCrewAITool("read_transcript")
+        guard = EnterpriseActionGuard(tool=tool, policy=policy)
+        with pytest.raises(PolicyViolationError):
+            guard._run()
+
+    # -----------------------------------------------------------------------
+    # Multiple allowed actions
+    # -----------------------------------------------------------------------
+
+    def test_multiple_allowed_actions_first_permitted(self) -> None:
+        tool = _StubCrewAITool("read_transcript")
+        guard = EnterpriseActionGuard(
+            tool=tool,
+            policy=_allow_policy("read_transcript", "read_enrollment", "read_grades"),
+        )
+        result = guard._run()
+        assert result == "tool_result"
+
+    def test_multiple_allowed_actions_unlisted_blocked(self) -> None:
+        tool = _StubCrewAITool("export_full_db")
+        guard = EnterpriseActionGuard(
+            tool=tool,
+            policy=_allow_policy("read_transcript", "read_enrollment"),
+        )
+        with pytest.raises(PolicyViolationError):
+            guard._run()
+
+    # -----------------------------------------------------------------------
+    # Duck-typed policy (can_run interface)
+    # -----------------------------------------------------------------------
+
+    def test_duck_typed_policy_with_can_run_permitted(self) -> None:
+        class _CanRunPolicy:
+            def can_run(self, action_name: str) -> bool:
+                return action_name == "safe_action"
+
+        tool = _StubCrewAITool("safe_action")
+        guard = EnterpriseActionGuard(tool=tool, policy=_CanRunPolicy())
+        result = guard._run()
+        assert result == "tool_result"
+
+    def test_duck_typed_policy_with_can_run_blocked(self) -> None:
+        class _CanRunPolicy:
+            def can_run(self, action_name: str) -> bool:
+                return False
+
+        tool = _StubCrewAITool("any_action")
+        guard = EnterpriseActionGuard(tool=tool, policy=_CanRunPolicy())
+        with pytest.raises(PolicyViolationError):
+            guard._run()
+
+
+# ===========================================================================
+# PolicyEnforcingAgent (AutoGen adapter)
+# ===========================================================================
+
+
+class TestPolicyEnforcingAgent:
+    def test_permitted_agent_generates_reply(self) -> None:
+        agent = _StubAutoGenAgent("advisor")
+        wrapped = PolicyEnforcingAgent(
+            agent=agent,
+            policy=_allow_policy("advisor"),
+        )
+        result = wrapped.generate_reply(messages=[{"content": "hello"}])
+        assert result == "agent_reply"
+        assert agent.generate_reply_count == 1
+
+    def test_blocked_agent_returns_blocked_reply(self) -> None:
+        agent = _StubAutoGenAgent("advisor")
+        wrapped = PolicyEnforcingAgent(
+            agent=agent,
+            policy=_allow_policy("other_agent"),
+        )
+        result = wrapped.generate_reply(messages=[])
+        assert result == "[Response blocked by compliance policy]"
+        assert agent.generate_reply_count == 0
+
+    def test_custom_blocked_reply_message(self) -> None:
+        agent = _StubAutoGenAgent("advisor")
+        wrapped = PolicyEnforcingAgent(
+            agent=agent,
+            policy=_allow_policy("other_agent"),
+            blocked_reply="COMPLIANCE VIOLATION — reply suppressed",
+        )
+        result = wrapped.generate_reply()
+        assert "COMPLIANCE VIOLATION" in result
+
+    def test_name_mirrors_underlying_agent(self) -> None:
+        agent = _StubAutoGenAgent("my-advisor-agent")
+        wrapped = PolicyEnforcingAgent(agent=agent, policy=_allow_policy("my-advisor-agent"))
+        assert wrapped.name == "my-advisor-agent"
+
+    def test_initiate_chat_delegates_to_agent(self) -> None:
+        agent = _StubAutoGenAgent("advisor")
+        wrapped = PolicyEnforcingAgent(agent=agent, policy=_allow_policy("advisor"))
+        result = wrapped.initiate_chat()
+        assert result == "chat_started"
+
+    def test_receive_delegates_to_agent(self) -> None:
+        agent = _StubAutoGenAgent("advisor")
+        wrapped = PolicyEnforcingAgent(agent=agent, policy=_allow_policy("advisor"))
+        result = wrapped.receive()
+        assert result == "received"
+
+    def test_permitted_emits_info_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        agent = _StubAutoGenAgent("advisor")
+        wrapped = PolicyEnforcingAgent(agent=agent, policy=_allow_policy("advisor"))
+        with caplog.at_level(logging.INFO, logger="regulated_ai_governance.adapters.autogen"):
+            wrapped.generate_reply()
+        assert any("permitted=True" in r.message for r in caplog.records)
+
+    def test_blocked_emits_warning_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        agent = _StubAutoGenAgent("advisor")
+        wrapped = PolicyEnforcingAgent(agent=agent, policy=_allow_policy("other_agent"))
+        with caplog.at_level(logging.WARNING, logger="regulated_ai_governance.adapters.autogen"):
+            wrapped.generate_reply()
+        assert any("autogen_policy_blocked" in r.message for r in caplog.records)
+
+    def test_duck_typed_can_run_policy_permits(self) -> None:
+        class _CanRunPolicy:
+            def can_run(self, action_name: str) -> bool:
+                return True
+
+        agent = _StubAutoGenAgent("advisor")
+        wrapped = PolicyEnforcingAgent(agent=agent, policy=_CanRunPolicy())
+        result = wrapped.generate_reply()
+        assert result == "agent_reply"
+
+    def test_duck_typed_can_run_policy_blocks(self) -> None:
+        class _CanRunPolicy:
+            def can_run(self, action_name: str) -> bool:
+                return False
+
+        agent = _StubAutoGenAgent("advisor")
+        wrapped = PolicyEnforcingAgent(agent=agent, policy=_CanRunPolicy())
+        result = wrapped.generate_reply()
+        assert "blocked" in result.lower()
+
+
+# ===========================================================================
+# PolicyKernelPlugin (Semantic Kernel adapter)
+# ===========================================================================
+
+
+class TestPolicyKernelPlugin:
+    def test_permitted_action_returns_true(self) -> None:
+        plugin = PolicyKernelPlugin(policy=_allow_policy("read_patient_data"))
+        assert plugin.check_action_permitted("read_patient_data") is True
+
+    def test_blocked_action_returns_false(self) -> None:
+        plugin = PolicyKernelPlugin(policy=_allow_policy("read_patient_data"))
+        assert plugin.check_action_permitted("delete_all_records") is False
+
+    def test_get_permitted_actions_returns_sorted_list(self) -> None:
+        policy = _allow_policy("write_note", "read_patient_data", "search_records")
+        plugin = PolicyKernelPlugin(policy=policy)
+        actions = plugin.get_permitted_actions()
+        assert actions == sorted(["write_note", "read_patient_data", "search_records"])
+
+    def test_get_permitted_actions_empty_policy_returns_empty_list(self) -> None:
+        policy = ActionPolicy(allowed_actions=set(), require_all_allowed=True)
+        plugin = PolicyKernelPlugin(policy=policy)
+        assert plugin.get_permitted_actions() == []
+
+    def test_check_action_emits_info_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        plugin = PolicyKernelPlugin(policy=_allow_policy("read_patient_data"))
+        with caplog.at_level(logging.INFO, logger="regulated_ai_governance.adapters.semantic_kernel"):
+            plugin.check_action_permitted("read_patient_data")
+        assert any("sk_policy_check" in r.message for r in caplog.records)
+
+    def test_duck_typed_can_run_policy_true(self) -> None:
+        class _CanRunPolicy:
+            def can_run(self, action_name: str) -> bool:
+                return action_name.startswith("read_")
+
+        plugin = PolicyKernelPlugin(policy=_CanRunPolicy())
+        assert plugin.check_action_permitted("read_data") is True
+        assert plugin.check_action_permitted("write_data") is False
+
+    def test_duck_typed_policy_without_allowed_actions_attr(self) -> None:
+        """get_permitted_actions returns [] if policy has no allowed_actions attribute."""
+
+        class _MinimalPolicy:
+            def permits(self, action_name: str) -> tuple[bool, str]:
+                return True, ""
+
+        plugin = PolicyKernelPlugin(policy=_MinimalPolicy())
+        assert plugin.get_permitted_actions() == []
+
+    def test_custom_regulation_citation_stored(self) -> None:
+        plugin = PolicyKernelPlugin(
+            policy=_allow_policy("read_data"),
+            regulation_citation="HIPAA 45 CFR § 164.308",
+        )
+        assert plugin._regulation_citation == "HIPAA 45 CFR § 164.308"
+
+    def test_multiple_allowed_actions_all_permitted(self) -> None:
+        policy = _allow_policy("action_a", "action_b", "action_c")
+        plugin = PolicyKernelPlugin(policy=policy)
+        for action in ("action_a", "action_b", "action_c"):
+            assert plugin.check_action_permitted(action) is True
+
+    def test_unlisted_action_denied_when_require_all(self) -> None:
+        policy = _allow_policy("action_a", "action_b")
+        plugin = PolicyKernelPlugin(policy=policy)
+        assert plugin.check_action_permitted("action_c") is False
+
+
+# ===========================================================================
+# __init__.py exports
+# ===========================================================================
+
+
+class TestAdaptersPackageExports:
+    def test_all_symbols_importable_from_adapters(self) -> None:
+        from regulated_ai_governance.adapters import (  # noqa: F401
+            EnterpriseActionGuard,
+            PolicyEnforcingAgent,
+            PolicyKernelPlugin,
+            PolicyViolationError,
+        )
+
+    def test_policy_violation_error_is_exception_subclass(self) -> None:
+        assert issubclass(PolicyViolationError, Exception)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -22,19 +22,13 @@ class TestGovernanceAuditRecord:
         assert record.permitted is True
 
     def test_record_id_is_auto_generated_uuid(self):
-        r1 = GovernanceAuditRecord(
-            regulation="FERPA", actor_id="a", action_name="x", permitted=True
-        )
-        r2 = GovernanceAuditRecord(
-            regulation="FERPA", actor_id="a", action_name="x", permitted=True
-        )
+        r1 = GovernanceAuditRecord(regulation="FERPA", actor_id="a", action_name="x", permitted=True)
+        r2 = GovernanceAuditRecord(regulation="FERPA", actor_id="a", action_name="x", permitted=True)
         assert r1.record_id != r2.record_id
         assert len(r1.record_id) == 36  # UUID4 format
 
     def test_timestamp_is_utc(self):
-        record = GovernanceAuditRecord(
-            regulation="HIPAA", actor_id="emp-001", action_name="read_phi", permitted=False
-        )
+        record = GovernanceAuditRecord(regulation="HIPAA", actor_id="emp-001", action_name="read_phi", permitted=False)
         assert record.timestamp.tzinfo == timezone.utc
 
     def test_to_log_entry_is_json_serializable(self):

--- a/tests/test_regulations.py
+++ b/tests/test_regulations.py
@@ -93,9 +93,7 @@ class TestHIPAATreatingProviderPolicy:
         assert permitted is False
 
     def test_escalates_external_share(self):
-        policy = make_hipaa_treating_provider_policy(
-            escalate_external_share_to="hipaa_privacy_officer"
-        )
+        policy = make_hipaa_treating_provider_policy(escalate_external_share_to="hipaa_privacy_officer")
         result = policy.escalation_for("share_records_externally", {})
         assert result is not None
         assert result.escalate_to == "hipaa_privacy_officer"
@@ -126,16 +124,12 @@ class TestHIPAAResearcherPolicy:
         assert permitted is True
 
     def test_denies_phi_export(self):
-        policy = make_hipaa_researcher_policy(
-            irb_approved_categories={"read_lab_results"}
-        )
+        policy = make_hipaa_researcher_policy(irb_approved_categories={"read_lab_results"})
         permitted, _ = policy.permits("export_phi")
         assert permitted is False
 
     def test_denies_clinical_note_creation(self):
-        policy = make_hipaa_researcher_policy(
-            irb_approved_categories={"read_lab_results"}
-        )
+        policy = make_hipaa_researcher_policy(irb_approved_categories={"read_lab_results"})
         permitted, _ = policy.permits("create_clinical_note")
         assert permitted is False
 


### PR DESCRIPTION
## Summary

- Adds `src/regulated_ai_governance/adapters/` package with three duck-typed framework adapter classes, each enforcing `ActionPolicy` without requiring hard SDK imports at module load time
- **`EnterpriseActionGuard`** (CrewAI): wraps any CrewAI tool via `_run`/`run`, raises `PolicyViolationError` on denial with structured audit logging (INFO on permit, WARNING on block)
- **`PolicyEnforcingAgent`** (AutoGen): wraps a `ConversableAgent`, gates `generate_reply` behind policy, returns configurable `blocked_reply` string on denial
- **`PolicyKernelPlugin`** (Semantic Kernel): exposes `check_action_permitted(action_name)` and `get_permitted_actions()` as SK-callable functions
- All three adapters support both the library's native `ActionPolicy.permits()` interface and duck-typed `can_run()` for external policy objects
- Regulatory basis: FERPA 34 CFR § 99.31(a)(1), HIPAA 45 CFR § 164.308(a)(4)

## Design notes

- Adapters live in `adapters/` (separate from existing `integrations/`): the integrations use `GovernedActionGuard` + Pydantic/crewai base classes directly; the adapters are lighter-weight duck-typed wrappers suitable for drop-in use without inheriting from SDK base classes
- `_import_*()` guards defer SDK import to instantiation time — the module is always importable even when optional extras are not installed
- Optional dependencies (`crewai>=1.0.0`, `pyautogen>=0.4.0`, `semantic-kernel>=1.0.0`) were already declared in `pyproject.toml`

## Test plan

- [x] 40 new tests in `tests/test_adapters.py` — all passing
- [x] Permit path: underlying tool/agent/function executes and returns result
- [x] Deny path: `PolicyViolationError` raised / blocked reply returned / `False` returned
- [x] `PolicyViolationError` dataclass fields (`action`, `policy_name`, `regulation_citation`) and `__str__` format verified
- [x] Audit log emission verified via `caplog` (INFO on permit, WARNING on block)
- [x] Duck-typed `can_run()` policy interface works alongside native `permits()` interface
- [x] `get_permitted_actions()` returns correctly sorted list; empty policy returns `[]`
- [x] Package `__all__` exports verified importable
- [x] Full existing test suite (115 tests) continues to pass — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)