### PR TITLE
docs(adr): add ADR-003 and ADR-004 — adapter pattern and framework-agnostic core

### DIFF
--- a/docs/adr/003-adapter-over-inheritance.md
+++ b/docs/adr/003-adapter-over-inheritance.md
@@ -1,0 +1,51 @@
+# ADR-003: Adapter Pattern over Inheritance for Framework Integration
+
+**Status:** Accepted  
+**Date:** 2026-04-12  
+**Deciders:** Ashutosh Rana
+
+## Context
+
+When integrating compliance policy enforcement with AI agent frameworks (CrewAI, AutoGen, LangChain, Semantic Kernel, Haystack), two structural approaches are available:
+
+1. **Inheritance:** Subclass the framework's base agent or tool class, override lifecycle methods to inject policy checks, and publish these as `FERPACrewAIAgent`, `HIPAAAutoGenAgent`, etc.
+2. **Adapter/Wrapper:** Define a thin wrapper class that holds a reference to the framework object and delegates to it after performing a policy check. The framework class itself is untouched.
+
+The choice has significant downstream consequences for the library's maintenance burden and consumer upgrade path.
+
+## Decision
+
+Use the adapter/wrapper pattern for all framework integrations. Framework classes are wrapped, not subclassed. The compliance core (`PolicyEngine`, `CompliancePolicy`, `AuditLogger`) has no imports from any agent framework. Framework-specific code lives exclusively in `adapters/<framework>.py`.
+
+## Rationale
+
+**Why adapters over inheritance:**
+
+Framework base classes change frequently. CrewAI v0.x to v1.x renamed tool base classes, changed `_run` signatures, and restructured the agent initialization API. AutoGen 0.2 to 0.4 introduced a new `ConversableAgent` architecture. If this library subclasses these base classes, each framework major version requires a subclass rewrite — and those rewrites are breaking changes for consumers who depend on the subclass API.
+
+Adapters are structurally decoupled: the wrapper holds a reference to the framework object and calls `_run()` or `generate_reply()` on it, but it does not depend on the internals of those classes. If the framework renames a method, only the adapter's 10-line delegation block needs updating, not a full subclass override chain.
+
+Duck typing makes this practical: CrewAI tools are duck-typed (they implement `_run`), and AutoGen agents are duck-typed (they implement `generate_reply`). The adapter can wrap any object that satisfies the interface without inheriting from a specific class.
+
+**Why adapter enables lazy imports:**
+
+The compliance core must import cleanly without any framework installed. An `import crewai` at the top of a module that defines `FERPACompliancePolicy` would make crewai a hard dependency of the entire library. With the adapter pattern, `adapters/crewai.py` does a lazy import inside `__init__` or `_run`, isolated behind a try/except that raises a helpful `ImportError` only when the adapter is actually instantiated. This lets teams use the HIPAA policy module without installing CrewAI.
+
+**Why not inheritance:**
+
+Inheritance also creates a naming collision problem. If CrewAI introduces a `BaseTool.validate()` method in a future version, and this library's `EnterpriseActionGuard` subclass defines its own `validate()` for policy validation, the two silently conflict. With an adapter, `EnterpriseActionGuard.validate_policy()` has no naming overlap with the wrapped tool's methods.
+
+## Consequences
+
+**Positive:**
+- Framework version upgrades require changes only in `adapters/<framework>.py`, never in the compliance core.
+- All framework imports are lazy and optional; installing the library without CrewAI does not cause import errors.
+- Unit tests for adapters use duck-typed stubs — no real framework install required in CI for the core test suite.
+- The adapter's public API (`EnterpriseActionGuard`, `PolicyEnforcingAgent`) can maintain a stable signature even as the wrapped framework changes its internal API.
+
+**Negative:**
+- Adapters cannot override framework lifecycle hooks that are invoked before the public methods reach the adapter (e.g., framework-internal pre-execution hooks). If a framework adds a built-in compliance feature in a future version, the adapter sits beside it rather than composing with it cleanly.
+- The consumer must explicitly wrap their tool/agent in the adapter. There is no transparent injection of policy enforcement — the wrapping step is visible in the consumer's code, which some teams find verbose.
+
+**Neutral:**
+- Each framework adapter is a separate file and can have its own optional dependency declaration in `pyproject.toml` (e.g., `crewai = ["crewai>=1.0"]`). This is a standard extras pattern and does not require separate packages.

--- a/docs/adr/004-framework-agnostic-core.md
+++ b/docs/adr/004-framework-agnostic-core.md
@@ -1,0 +1,52 @@
+# ADR-004: Framework-Agnostic Compliance Core with Thin Framework Adapters
+
+**Status:** Accepted  
+**Date:** 2026-04-12  
+**Deciders:** Ashutosh Rana
+
+## Context
+
+Regulated AI governance tooling must work across the ecosystem of agent frameworks in active use: CrewAI, AutoGen, LangChain, Semantic Kernel, and Haystack each have significant enterprise adoption in different verticals (healthcare, financial services, higher education). No single framework dominates; enterprise teams frequently run multiple frameworks in the same organization, and sometimes in the same pipeline.
+
+Two structural options were considered:
+
+1. **Framework-coupled design:** Build the compliance engine as an extension module for a specific framework (e.g., a LangChain `BaseCallback` subclass). Re-implement for each additional framework.
+2. **Framework-agnostic core with thin adapters:** The policy engine, regulation objects, and audit logger have zero framework imports. Adapters in `adapters/<framework>.py` translate framework-specific hooks to core API calls.
+
+## Decision
+
+The compliance core (`PolicyEngine`, `ActionPolicy`, `ComplianceViolationError`, `AuditLogger`) contains no imports from any agent framework. All framework coupling is isolated in thin adapter modules under `adapters/`. The core is tested independently of any framework.
+
+## Rationale
+
+**Framework churn is the primary risk:**
+
+The AI agent framework space is less than three years old and has already seen multiple breaking API revisions (LangChain 0.1 → 0.2 callback restructure; AutoGen 0.2 → 0.4 agent model rewrite; CrewAI 0.x → 1.x tool interface change). A compliance library that tightly couples to any one framework's internals faces forced rewrites on every framework major version, with those rewrites landing as breaking changes for consumers.
+
+A framework-agnostic core insulates the compliance logic from this churn. The policy engine for FERPA, HIPAA, or GLBA is stable — the regulation's requirements do not change with CrewAI's release cycle.
+
+**Auditability requires portability:**
+
+In regulated environments, the audit log format must be consistent regardless of which framework produced the agent action. If FERPA audit records from a LangChain-based agent have a different schema than records from a CrewAI-based agent, compliance reporting requires per-framework log parsers. A framework-agnostic `AuditRecord` type, written to by all adapters through a common `AuditLogger` interface, produces a uniform audit trail.
+
+**Test isolation:**
+
+Compliance logic is the most critical path in the library — a policy bypass is a regulatory violation. If compliance tests require a real CrewAI or AutoGen installation, CI becomes fragile (framework install failures cause compliance test failures) and slow (large framework installs on each CI run). With a framework-agnostic core, the policy engine's full test suite runs with zero framework dependencies in under two seconds.
+
+**Multi-framework enterprise deployments:**
+
+A healthcare organization may use LangChain for retrieval pipelines and CrewAI for multi-agent scheduling, both subject to HIPAA. The HIPAA `PHIScope` object and `MinimumNecessaryPolicy` must be sharable across both frameworks without duplication. A framework-agnostic core makes this natural.
+
+## Consequences
+
+**Positive:**
+- Adding a new framework adapter (e.g., Haystack, Autogen v5) requires writing one file in `adapters/` and adding an optional dependency — the compliance core is untouched.
+- Core unit tests are fast and framework-install-free.
+- A single `AuditRecord` schema covers all frameworks, enabling unified SIEM integration.
+
+**Negative:**
+- The adapter pattern means framework-specific features (e.g., LangChain's streaming callback chain, AutoGen's group chat message routing) must be mapped to the core API by the adapter author. If a framework introduces a novel execution model with no analog in the core API, the adapter may need to approximate the compliance check rather than integrate perfectly.
+- Consumers who use only one framework carry a small overhead: they import the adapter layer in addition to the core. For a compliance library this overhead (~2 files, ~200 lines) is immaterial.
+
+**Neutral:**
+- The `adapters/` package is structured so each adapter file is independently importable. A consumer using only CrewAI never loads the AutoGen adapter, and vice versa. This prevents unnecessary import of framework packages the consumer has not installed.


### PR DESCRIPTION
## Summary
- **ADR-003** (`003-adapter-over-inheritance.md`): Documents the adapter/wrapper pattern decision for framework integration (CrewAI, AutoGen, LangChain, SK, Haystack). Explains why subclassing framework base classes is fragile against framework major-version churn, and how adapters enable lazy imports, duck-typed stubs in tests, and stable public APIs.
- **ADR-004** (`004-framework-agnostic-core.md`): Documents the zero-framework-imports policy for the compliance core (`PolicyEngine`, `ActionPolicy`, `AuditLogger`). Covers the multi-framework enterprise deployment scenario, uniform audit record schema, and CI test speed rationale.

These complement the existing ADR-001 (policy-before-execution) and ADR-002 (regulation-per-factory) with structural architecture decisions.

## Test plan
- [ ] Review ADR-003 against `adapters/crewai.py` and `adapters/autogen.py` implementation
- [ ] Confirm compliance core imports no framework packages
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)