### PR TITLE
feat: add GovernanceCallbackHandler and comprehensive LangChain integration tests

### DIFF
--- a/src/regulated_ai_governance/agent_guard.py
+++ b/src/regulated_ai_governance/agent_guard.py
@@ -155,9 +155,7 @@ class GovernedActionGuard:
             action_name=action_name,
             permitted=decision.permitted,
             denial_reason=decision.denial_reason,
-            escalation_target=(
-                decision.escalation.escalate_to if decision.escalation else None
-            ),
+            escalation_target=(decision.escalation.escalate_to if decision.escalation else None),
             context=context or {},
             policy_version=self._policy_version,
         )
@@ -190,13 +188,9 @@ class GovernedActionGuard:
         self._emit_audit(action_name, decision, context)
 
         if not decision.permitted:
-            message = (
-                f"[regulated-ai-governance] Action BLOCKED — {decision.denial_reason}"
-            )
+            message = f"[regulated-ai-governance] Action BLOCKED — {decision.denial_reason}"
             if decision.escalation:
-                message += (
-                    f" | Escalation target: {decision.escalation.escalate_to}"
-                )
+                message += f" | Escalation target: {decision.escalation.escalate_to}"
             if self._raise_on_deny:
                 raise PermissionError(message)
             return message

--- a/src/regulated_ai_governance/integrations/crewai.py
+++ b/src/regulated_ai_governance/integrations/crewai.py
@@ -43,8 +43,7 @@ try:
     from pydantic import PrivateAttr
 except ImportError as exc:
     raise ImportError(
-        "crewai is required for this integration. "
-        "Install it with: pip install regulated-ai-governance[crewai]"
+        "crewai is required for this integration. Install it with: pip install regulated-ai-governance[crewai]"
     ) from exc
 
 from regulated_ai_governance.agent_guard import GovernedActionGuard

--- a/src/regulated_ai_governance/integrations/langchain.py
+++ b/src/regulated_ai_governance/integrations/langchain.py
@@ -133,7 +133,8 @@ class FERPAComplianceCallbackHandler(BaseCallbackHandler):
     def _apply_identity_filter(self, documents: list[Document]) -> list[Document]:
         """Layer 1: filter by student_id + institution_id."""
         return [
-            doc for doc in documents
+            doc
+            for doc in documents
             if (
                 doc.metadata.get(self.student_id_field) == self.student_id
                 and doc.metadata.get(self.institution_id_field) == self.institution_id
@@ -144,10 +145,7 @@ class FERPAComplianceCallbackHandler(BaseCallbackHandler):
         """Layer 2: filter by allowed_categories."""
         if not self.allowed_categories:
             return documents
-        return [
-            doc for doc in documents
-            if doc.metadata.get(self.category_field) in self.allowed_categories
-        ]
+        return [doc for doc in documents if doc.metadata.get(self.category_field) in self.allowed_categories]
 
     def on_retriever_end(
         self,
@@ -192,11 +190,7 @@ class FERPAComplianceCallbackHandler(BaseCallbackHandler):
                     "parent_run_id": str(parent_run_id) if parent_run_id else None,
                     "student_id": self.student_id,
                     "institution_id": self.institution_id,
-                    "allowed_categories": (
-                        sorted(self.allowed_categories)
-                        if self.allowed_categories
-                        else None
-                    ),
+                    "allowed_categories": (sorted(self.allowed_categories) if self.allowed_categories else None),
                 },
             )
             self.audit_sink(record)
@@ -299,9 +293,7 @@ class GovernanceCallbackHandler(BaseCallbackHandler):
                 action_name=tool_name,
                 permitted=decision.permitted,
                 denial_reason=decision.denial_reason,
-                escalation_target=(
-                    decision.escalation.escalate_to if decision.escalation else None
-                ),
+                escalation_target=(decision.escalation.escalate_to if decision.escalation else None),
                 context={
                     "run_id": str(run_id),
                     "parent_run_id": str(parent_run_id) if parent_run_id else None,
@@ -334,7 +326,5 @@ class GovernanceCallbackHandler(BaseCallbackHandler):
     def on_tool_end(self, output: str, *, run_id: uuid.UUID, **kwargs: Any) -> None:
         """No-op: tool end event."""
 
-    def on_tool_error(
-        self, error: BaseException | KeyboardInterrupt, *, run_id: uuid.UUID, **kwargs: Any
-    ) -> None:
+    def on_tool_error(self, error: BaseException | KeyboardInterrupt, *, run_id: uuid.UUID, **kwargs: Any) -> None:
         """No-op: tool error event."""

--- a/src/regulated_ai_governance/integrations/langchain.py
+++ b/src/regulated_ai_governance/integrations/langchain.py
@@ -1,26 +1,28 @@
 """
-LangChain integration — ``FERPAComplianceCallbackHandler``.
+LangChain integration — ``FERPAComplianceCallbackHandler`` and
+``GovernanceCallbackHandler``.
 
-Intercepts retrieval results in a LangChain chain and applies identity-scoped
-FERPA filtering before retrieved documents reach the LLM context window.
-Produces a ``GovernanceAuditRecord`` for each retrieval event.
+Provides two LangChain callback handler classes for regulated AI environments:
 
-This integration enforces the two-layer FERPA boundary described in the
-enterprise-rag-patterns library:
+1. ``FERPAComplianceCallbackHandler``
+   Intercepts retrieval results and applies identity-scoped FERPA filtering
+   before retrieved documents reach the LLM context window.  Produces a
+   ``GovernanceAuditRecord`` for each retrieval event (34 CFR § 99.32).
 
-- Layer 1 (identity pre-filter): only documents with matching ``student_id``
-  and ``institution_id`` metadata pass.
-- Layer 2 (category authorization): only documents whose ``category`` field
-  is in ``allowed_categories`` pass.
-
-The ``GovernanceAuditRecord`` emitted per retrieval satisfies the disclosure
-logging requirement at 34 CFR § 99.32.
+2. ``GovernanceCallbackHandler``
+   Intercepts ``on_tool_start`` events and evaluates each tool invocation
+   against an ``ActionPolicy`` before execution proceeds.  This implements
+   the "policy-before-execution" principle from ADR-0001: the governance
+   check runs synchronously inside the callback so the LangChain chain
+   cannot proceed to tool execution without a valid policy decision.
+   Produces a ``GovernanceAuditRecord`` for every tool invocation event,
+   whether permitted or denied.
 
 Installation:
     pip install regulated-ai-governance[langchain]
 
-Usage:
-    from langchain_community.vectorstores import FAISS
+Usage — FERPA retrieval filter::
+
     from regulated_ai_governance.integrations.langchain import (
         FERPAComplianceCallbackHandler,
     )
@@ -32,14 +34,30 @@ Usage:
         allowed_categories={"academic_record", "financial_record"},
         audit_sink=audit_log.append,
     )
-
     retriever = vector_store.as_retriever(callbacks=[handler])
     docs = retriever.invoke("What is my enrollment status?")
-    # docs contains only Alice's authorized records at univ-east
+
+Usage — tool-level governance::
+
+    from regulated_ai_governance.integrations.langchain import (
+        GovernanceCallbackHandler,
+    )
+    from regulated_ai_governance.policy import ActionPolicy
+
+    policy = ActionPolicy(allowed_actions={"search_catalog", "read_transcript"})
+    gov_handler = GovernanceCallbackHandler(
+        policy=policy,
+        regulation="FERPA",
+        actor_id="stu-alice",
+        audit_sink=audit_log.append,
+    )
+    # Pass gov_handler to a LangChain agent or chain via callbacks=[gov_handler]
+    # The handler raises PermissionError before any denied tool executes.
 """
 
 from __future__ import annotations
 
+import logging
 import uuid
 from collections.abc import Callable
 from typing import Any
@@ -53,7 +71,11 @@ except ImportError as exc:
         "Install it with: pip install regulated-ai-governance[langchain]"
     ) from exc
 
+from regulated_ai_governance.agent_guard import GovernedActionGuard
 from regulated_ai_governance.audit import GovernanceAuditRecord
+from regulated_ai_governance.policy import ActionPolicy
+
+logger = logging.getLogger(__name__)
 
 
 class FERPAComplianceCallbackHandler(BaseCallbackHandler):
@@ -188,3 +210,131 @@ class FERPAComplianceCallbackHandler(BaseCallbackHandler):
             )
 
         return authorized
+
+
+class GovernanceCallbackHandler(BaseCallbackHandler):
+    """
+    LangChain callback handler that enforces ``ActionPolicy`` governance on
+    every tool invocation before execution proceeds.
+
+    Implements the "policy-before-execution" principle from ADR-0001:
+    ``on_tool_start`` is called synchronously by LangChain before the tool
+    function runs, so raising ``PermissionError`` here prevents execution.
+
+    For every tool invocation event, a ``GovernanceAuditRecord`` is emitted
+    to the ``audit_sink`` whether the action is permitted or denied.
+
+    Regulation citations for common frameworks:
+    - FERPA § 99.31(a)(1): access control for school official tools
+    - HIPAA § 164.312(a)(1): access controls for PHI-touching tools
+    - GLBA § 314.4(c): access controls for customer financial data tools
+    - SOC 2 CC6.1: logical access controls for agent-invoked operations
+
+    :param policy: ``ActionPolicy`` defining which tool names are permitted.
+        Tool names are matched against ``allowed_actions`` and ``denied_actions``.
+    :param regulation: Regulation name written to each ``GovernanceAuditRecord``
+        (e.g. ``"FERPA"``, ``"HIPAA"``, ``"GLBA"``).
+    :param actor_id: Authenticated principal identifier. Must originate from
+        the verified session, not user input.
+    :param audit_sink: Optional callable receiving each ``GovernanceAuditRecord``.
+        Wire to a durable compliance log store.
+    :param tool_name_field: Key in the serialised tool dict whose value is
+        used as the action name for policy evaluation. Default: ``"name"``.
+    :param block_on_escalation: If ``True`` (default), escalated tools are
+        blocked even if the policy would otherwise permit them.
+    """
+
+    def __init__(
+        self,
+        policy: ActionPolicy,
+        regulation: str = "FERPA",
+        actor_id: str = "unknown",
+        audit_sink: Callable[[GovernanceAuditRecord], None] | None = None,
+        tool_name_field: str = "name",
+        block_on_escalation: bool = True,
+    ) -> None:
+        super().__init__()
+        self.regulation = regulation
+        self.actor_id = actor_id
+        self._audit_sink = audit_sink
+        self._guard = GovernedActionGuard(
+            policy=policy,
+            regulation=regulation,
+            actor_id=actor_id,
+            audit_sink=audit_sink,
+            block_on_escalation=block_on_escalation,
+        )
+        self.tool_name_field = tool_name_field
+
+    def on_tool_start(
+        self,
+        serialized: dict[str, Any],
+        input_str: str,
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: uuid.UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Intercept tool invocations and evaluate against ``ActionPolicy``.
+
+        Called by the LangChain callback system synchronously before the tool
+        function executes.  Raising ``PermissionError`` here prevents execution.
+
+        :param serialized: LangChain serialised tool description dict.  The
+            tool name is read from ``serialized[self.tool_name_field]``.
+        :param input_str: Raw string input to the tool (for audit context).
+        :param run_id: LangChain run identifier for this tool invocation.
+        :param parent_run_id: Parent run identifier.
+        :raises PermissionError: If the tool name is not permitted by the policy.
+        """
+        tool_name = serialized.get(self.tool_name_field, "unknown_tool")
+        decision = self._guard.evaluate(tool_name)
+
+        # Emit audit record for every tool invocation (permitted or denied)
+        if self._audit_sink is not None:
+            record = GovernanceAuditRecord(
+                regulation=self.regulation,
+                actor_id=self.actor_id,
+                action_name=tool_name,
+                permitted=decision.permitted,
+                denial_reason=decision.denial_reason,
+                escalation_target=(
+                    decision.escalation.escalate_to if decision.escalation else None
+                ),
+                context={
+                    "run_id": str(run_id),
+                    "parent_run_id": str(parent_run_id) if parent_run_id else None,
+                    "input": input_str,
+                },
+            )
+            self._audit_sink(record)
+
+        if not decision.permitted:
+            logger.warning(
+                "[GOVERNANCE] Tool blocked: tool=%r actor=%r regulation=%r reason=%r",
+                tool_name,
+                self.actor_id,
+                self.regulation,
+                decision.denial_reason,
+            )
+            raise PermissionError(
+                f"GovernanceCallbackHandler: tool '{tool_name}' is not permitted "
+                f"for actor '{self.actor_id}' under {self.regulation} policy. "
+                f"Reason: {decision.denial_reason}"
+            )
+
+        logger.debug(
+            "[GOVERNANCE] Tool permitted: tool=%r actor=%r regulation=%r",
+            tool_name,
+            self.actor_id,
+            self.regulation,
+        )
+
+    def on_tool_end(self, output: str, *, run_id: uuid.UUID, **kwargs: Any) -> None:
+        """No-op: tool end event."""
+
+    def on_tool_error(
+        self, error: BaseException | KeyboardInterrupt, *, run_id: uuid.UUID, **kwargs: Any
+    ) -> None:
+        """No-op: tool error event."""

--- a/src/regulated_ai_governance/policy.py
+++ b/src/regulated_ai_governance/policy.py
@@ -90,15 +90,12 @@ class ActionPolicy:
         if self.allowed_actions and self.require_all_allowed:
             if action_name not in self.allowed_actions:
                 return False, (
-                    f"Action '{action_name}' is not in the allowed actions set. "
-                    f"Allowed: {sorted(self.allowed_actions)}"
+                    f"Action '{action_name}' is not in the allowed actions set. Allowed: {sorted(self.allowed_actions)}"
                 )
 
         return True, ""
 
-    def escalation_for(
-        self, action_name: str, context: dict | None = None
-    ) -> EscalationRule | None:
+    def escalation_for(self, action_name: str, context: dict | None = None) -> EscalationRule | None:
         """
         Return the first ``EscalationRule`` that matches *action_name*, or None.
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -22,19 +22,13 @@ class TestGovernanceAuditRecord:
         assert record.permitted is True
 
     def test_record_id_is_auto_generated_uuid(self):
-        r1 = GovernanceAuditRecord(
-            regulation="FERPA", actor_id="a", action_name="x", permitted=True
-        )
-        r2 = GovernanceAuditRecord(
-            regulation="FERPA", actor_id="a", action_name="x", permitted=True
-        )
+        r1 = GovernanceAuditRecord(regulation="FERPA", actor_id="a", action_name="x", permitted=True)
+        r2 = GovernanceAuditRecord(regulation="FERPA", actor_id="a", action_name="x", permitted=True)
         assert r1.record_id != r2.record_id
         assert len(r1.record_id) == 36  # UUID4 format
 
     def test_timestamp_is_utc(self):
-        record = GovernanceAuditRecord(
-            regulation="HIPAA", actor_id="emp-001", action_name="read_phi", permitted=False
-        )
+        record = GovernanceAuditRecord(regulation="HIPAA", actor_id="emp-001", action_name="read_phi", permitted=False)
         assert record.timestamp.tzinfo == timezone.utc
 
     def test_to_log_entry_is_json_serializable(self):

--- a/tests/test_langchain_integration.py
+++ b/tests/test_langchain_integration.py
@@ -13,15 +13,14 @@ import sys
 import types
 import uuid
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Mock langchain_core before the module under test is imported.
 # We do this at module level so the import at the top of langchain.py works.
 # ---------------------------------------------------------------------------
+
 
 def _install_langchain_core_mock() -> None:
     """Inject minimal langchain_core stubs into sys.modules."""
@@ -64,10 +63,10 @@ from regulated_ai_governance.integrations.langchain import (  # noqa: E402
 )
 from regulated_ai_governance.policy import ActionPolicy, EscalationRule  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Stubs
 # ---------------------------------------------------------------------------
+
 
 class _FakeDocument:
     """Duck-typed Document stub with .metadata dict."""
@@ -107,7 +106,11 @@ class TestFERPAComplianceCallbackHandler:
 
     def test_allows_authorized_document(self) -> None:
         handler = self._make_handler()
-        docs = [_FakeDocument("Transcript", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "academic_record"})]
+        docs = [
+            _FakeDocument(
+                "Transcript", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "academic_record"}
+            )
+        ]
         result = handler.on_retriever_end(docs, run_id=_run_id())
         assert len(result) == 1
 
@@ -134,8 +137,12 @@ class TestFERPAComplianceCallbackHandler:
     def test_category_filter_blocks_unauthorized(self) -> None:
         handler = self._make_handler(allowed_categories={"academic_record"})
         docs = [
-            _FakeDocument("Transcript", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "academic_record"}),
-            _FakeDocument("Health", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "health_record"}),
+            _FakeDocument(
+                "Transcript", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "academic_record"}
+            ),
+            _FakeDocument(
+                "Health", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "health_record"}
+            ),
         ]
         result = handler.on_retriever_end(docs, run_id=_run_id())
         assert len(result) == 1
@@ -144,7 +151,9 @@ class TestFERPAComplianceCallbackHandler:
     def test_no_category_filter_when_none(self) -> None:
         handler = self._make_handler(allowed_categories=None)
         docs = [
-            _FakeDocument("Health", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "health_record"}),
+            _FakeDocument(
+                "Health", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "health_record"}
+            ),
         ]
         result = handler.on_retriever_end(docs, run_id=_run_id())
         assert len(result) == 1
@@ -207,15 +216,17 @@ class TestFERPAComplianceCallbackHandler:
             audit_sink=audit_log.append,
         )
         docs = [
-            _FakeDocument("T", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "academic_record"}),
+            _FakeDocument(
+                "T", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "academic_record"}
+            ),
             _FakeDocument("B", {"student_id": "stu_bob", "institution_id": "univ_east", "category": "academic_record"}),
             _FakeDocument("H", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "health_record"}),
         ]
         handler.on_retriever_end(docs, run_id=_run_id())
         ctx = audit_log[0].context
         assert ctx["documents_in_store"] == 3
-        assert ctx["after_identity_filter"] == 2   # alice's docs
-        assert ctx["after_category_filter"] == 1   # only academic_record
+        assert ctx["after_identity_filter"] == 2  # alice's docs
+        assert ctx["after_category_filter"] == 1  # only academic_record
 
     def test_custom_field_names(self) -> None:
         handler = FERPAComplianceCallbackHandler(

--- a/tests/test_langchain_integration.py
+++ b/tests/test_langchain_integration.py
@@ -1,0 +1,411 @@
+"""
+Tests for regulated_ai_governance.integrations.langchain:
+  - FERPAComplianceCallbackHandler (retrieval filter)
+  - GovernanceCallbackHandler (tool policy enforcement)
+
+Uses sys.modules mocking to satisfy the langchain-core hard import at module
+load time — no actual SDK install required.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Mock langchain_core before the module under test is imported.
+# We do this at module level so the import at the top of langchain.py works.
+# ---------------------------------------------------------------------------
+
+def _install_langchain_core_mock() -> None:
+    """Inject minimal langchain_core stubs into sys.modules."""
+    if "langchain_core" in sys.modules:
+        return  # already loaded (real or mock)
+
+    # Build stub modules
+    langchain_core = types.ModuleType("langchain_core")
+    langchain_core_callbacks = types.ModuleType("langchain_core.callbacks")
+    langchain_core_documents = types.ModuleType("langchain_core.documents")
+
+    # BaseCallbackHandler stub
+    class BaseCallbackHandler:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    # Document stub
+    class Document:
+        def __init__(self, page_content: str = "", metadata: dict | None = None) -> None:
+            self.page_content = page_content
+            self.metadata = metadata or {}
+
+    langchain_core_callbacks.BaseCallbackHandler = BaseCallbackHandler  # type: ignore[attr-defined]
+    langchain_core_documents.Document = Document  # type: ignore[attr-defined]
+
+    sys.modules["langchain_core"] = langchain_core
+    sys.modules["langchain_core.callbacks"] = langchain_core_callbacks
+    sys.modules["langchain_core.documents"] = langchain_core_documents
+    langchain_core.callbacks = langchain_core_callbacks  # type: ignore[attr-defined]
+    langchain_core.documents = langchain_core_documents  # type: ignore[attr-defined]
+
+
+_install_langchain_core_mock()
+
+# Now import the module under test (langchain_core stubs are in sys.modules)
+from regulated_ai_governance.audit import GovernanceAuditRecord  # noqa: E402
+from regulated_ai_governance.integrations.langchain import (  # noqa: E402
+    FERPAComplianceCallbackHandler,
+    GovernanceCallbackHandler,
+)
+from regulated_ai_governance.policy import ActionPolicy, EscalationRule  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+class _FakeDocument:
+    """Duck-typed Document stub with .metadata dict."""
+
+    def __init__(self, content: str, metadata: dict[str, Any]) -> None:
+        self.page_content = content
+        self.metadata = metadata
+
+
+def _run_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+# ---------------------------------------------------------------------------
+# FERPAComplianceCallbackHandler Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFERPAComplianceCallbackHandler:
+    """Tests for the retrieval identity-scope filter."""
+
+    def _make_handler(
+        self,
+        student_id: str = "stu_alice",
+        institution_id: str = "univ_east",
+        allowed_categories: set[str] | None = None,
+        audit_sink: Any = None,
+        raise_on_empty: bool = False,
+    ) -> FERPAComplianceCallbackHandler:
+        return FERPAComplianceCallbackHandler(
+            student_id=student_id,
+            institution_id=institution_id,
+            allowed_categories=allowed_categories,
+            audit_sink=audit_sink,
+            raise_on_empty=raise_on_empty,
+        )
+
+    def test_allows_authorized_document(self) -> None:
+        handler = self._make_handler()
+        docs = [_FakeDocument("Transcript", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "academic_record"})]
+        result = handler.on_retriever_end(docs, run_id=_run_id())
+        assert len(result) == 1
+
+    def test_blocks_cross_student(self) -> None:
+        handler = self._make_handler(student_id="stu_alice")
+        docs = [
+            _FakeDocument("Alice", {"student_id": "stu_alice", "institution_id": "univ_east"}),
+            _FakeDocument("Bob", {"student_id": "stu_bob", "institution_id": "univ_east"}),
+        ]
+        result = handler.on_retriever_end(docs, run_id=_run_id())
+        assert len(result) == 1
+        assert result[0].metadata["student_id"] == "stu_alice"
+
+    def test_blocks_cross_institution(self) -> None:
+        handler = self._make_handler(institution_id="univ_east")
+        docs = [
+            _FakeDocument("Alice at East", {"student_id": "stu_alice", "institution_id": "univ_east"}),
+            _FakeDocument("Alice at West", {"student_id": "stu_alice", "institution_id": "univ_west"}),
+        ]
+        result = handler.on_retriever_end(docs, run_id=_run_id())
+        assert len(result) == 1
+        assert result[0].metadata["institution_id"] == "univ_east"
+
+    def test_category_filter_blocks_unauthorized(self) -> None:
+        handler = self._make_handler(allowed_categories={"academic_record"})
+        docs = [
+            _FakeDocument("Transcript", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "academic_record"}),
+            _FakeDocument("Health", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "health_record"}),
+        ]
+        result = handler.on_retriever_end(docs, run_id=_run_id())
+        assert len(result) == 1
+        assert result[0].metadata["category"] == "academic_record"
+
+    def test_no_category_filter_when_none(self) -> None:
+        handler = self._make_handler(allowed_categories=None)
+        docs = [
+            _FakeDocument("Health", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "health_record"}),
+        ]
+        result = handler.on_retriever_end(docs, run_id=_run_id())
+        assert len(result) == 1
+
+    def test_document_without_identity_fields_is_filtered(self) -> None:
+        """
+        Documents without student/institution fields are filtered out.
+
+        Note: This implementation requires an exact student_id + institution_id
+        match. Documents with no identity metadata do not pass through — they
+        are treated as unidentified records, not as shared KB content.
+        For shared-KB pass-through behavior, use the enterprise-rag-patterns
+        FERPAHaystackFilter which has explicit shared-KB logic.
+        """
+        handler = self._make_handler()
+        docs = [_FakeDocument("General FAQ", {})]
+        result = handler.on_retriever_end(docs, run_id=_run_id())
+        # No identity fields → identity filter blocks (None != "stu_alice")
+        assert len(result) == 0
+
+    def test_empty_input_returns_empty(self) -> None:
+        handler = self._make_handler()
+        result = handler.on_retriever_end([], run_id=_run_id())
+        assert result == []
+
+    def test_raise_on_empty_raises_permission_error(self) -> None:
+        handler = self._make_handler(raise_on_empty=True)
+        docs = [_FakeDocument("Bob", {"student_id": "stu_bob", "institution_id": "univ_east"})]
+        with pytest.raises(PermissionError, match="stu_alice"):
+            handler.on_retriever_end(docs, run_id=_run_id())
+
+    def test_raise_on_empty_false_does_not_raise(self) -> None:
+        handler = self._make_handler(raise_on_empty=False)
+        docs = [_FakeDocument("Bob", {"student_id": "stu_bob", "institution_id": "univ_east"})]
+        result = handler.on_retriever_end(docs, run_id=_run_id())
+        assert result == []
+
+    def test_audit_sink_called_on_retrieval(self) -> None:
+        audit_log: list[GovernanceAuditRecord] = []
+        handler = self._make_handler(audit_sink=audit_log.append)
+        docs = [_FakeDocument("Transcript", {"student_id": "stu_alice", "institution_id": "univ_east"})]
+        handler.on_retriever_end(docs, run_id=_run_id())
+        assert len(audit_log) == 1
+        record = audit_log[0]
+        assert record.regulation == "FERPA"
+        assert record.action_name == "retrieval"
+        assert record.permitted is True
+
+    def test_audit_sink_not_called_when_none(self) -> None:
+        """No error when audit_sink is None."""
+        handler = self._make_handler(audit_sink=None)
+        docs = [_FakeDocument("Transcript", {"student_id": "stu_alice", "institution_id": "univ_east"})]
+        result = handler.on_retriever_end(docs, run_id=_run_id())
+        assert len(result) == 1
+
+    def test_audit_record_contains_document_counts(self) -> None:
+        audit_log: list[GovernanceAuditRecord] = []
+        handler = self._make_handler(
+            allowed_categories={"academic_record"},
+            audit_sink=audit_log.append,
+        )
+        docs = [
+            _FakeDocument("T", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "academic_record"}),
+            _FakeDocument("B", {"student_id": "stu_bob", "institution_id": "univ_east", "category": "academic_record"}),
+            _FakeDocument("H", {"student_id": "stu_alice", "institution_id": "univ_east", "category": "health_record"}),
+        ]
+        handler.on_retriever_end(docs, run_id=_run_id())
+        ctx = audit_log[0].context
+        assert ctx["documents_in_store"] == 3
+        assert ctx["after_identity_filter"] == 2   # alice's docs
+        assert ctx["after_category_filter"] == 1   # only academic_record
+
+    def test_custom_field_names(self) -> None:
+        handler = FERPAComplianceCallbackHandler(
+            student_id="stu_alice",
+            institution_id="univ_east",
+            student_id_field="learner_id",
+            institution_id_field="school_id",
+        )
+        docs = [
+            _FakeDocument("Alice", {"learner_id": "stu_alice", "school_id": "univ_east"}),
+            _FakeDocument("Bob", {"learner_id": "stu_bob", "school_id": "univ_east"}),
+        ]
+        result = handler.on_retriever_end(docs, run_id=_run_id())
+        assert len(result) == 1
+        assert result[0].metadata["learner_id"] == "stu_alice"
+
+    def test_mixed_batch_all_filtered(self) -> None:
+        handler = self._make_handler(raise_on_empty=False)
+        docs = [
+            _FakeDocument("Bob", {"student_id": "stu_bob", "institution_id": "univ_east"}),
+            _FakeDocument("Cross-inst", {"student_id": "stu_alice", "institution_id": "univ_west"}),
+        ]
+        result = handler.on_retriever_end(docs, run_id=_run_id())
+        assert result == []
+
+    def test_parent_run_id_in_audit_context(self) -> None:
+        audit_log: list[GovernanceAuditRecord] = []
+        handler = self._make_handler(audit_sink=audit_log.append)
+        parent = _run_id()
+        docs = [_FakeDocument("T", {"student_id": "stu_alice", "institution_id": "univ_east"})]
+        handler.on_retriever_end(docs, run_id=_run_id(), parent_run_id=parent)
+        assert audit_log[0].context["parent_run_id"] == str(parent)
+
+
+# ---------------------------------------------------------------------------
+# GovernanceCallbackHandler Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceCallbackHandler:
+    """Tests for the tool-level ActionPolicy enforcement handler."""
+
+    def _make_handler(
+        self,
+        allowed_actions: set[str] | None = None,
+        denied_actions: set[str] | None = None,
+        regulation: str = "FERPA",
+        actor_id: str = "stu_alice",
+        audit_sink: Any = None,
+        block_on_escalation: bool = True,
+        escalation_rules: list | None = None,
+    ) -> GovernanceCallbackHandler:
+        policy = ActionPolicy(
+            allowed_actions=allowed_actions or {"search_catalog", "read_transcript"},
+            denied_actions=denied_actions or set(),
+            escalation_rules=escalation_rules or [],
+        )
+        return GovernanceCallbackHandler(
+            policy=policy,
+            regulation=regulation,
+            actor_id=actor_id,
+            audit_sink=audit_sink,
+            block_on_escalation=block_on_escalation,
+        )
+
+    def _serialized(self, name: str) -> dict[str, Any]:
+        return {"name": name, "description": f"Tool: {name}"}
+
+    def test_permitted_tool_does_not_raise(self) -> None:
+        handler = self._make_handler(allowed_actions={"search_catalog"})
+        # Should not raise
+        handler.on_tool_start(self._serialized("search_catalog"), "query", run_id=_run_id())
+
+    def test_denied_tool_raises_permission_error(self) -> None:
+        handler = self._make_handler(allowed_actions={"search_catalog"})
+        with pytest.raises(PermissionError, match="export_records"):
+            handler.on_tool_start(self._serialized("export_records"), "args", run_id=_run_id())
+
+    def test_explicitly_denied_tool_raises(self) -> None:
+        handler = self._make_handler(
+            allowed_actions={"search_catalog", "delete_record"},
+            denied_actions={"delete_record"},
+        )
+        with pytest.raises(PermissionError, match="delete_record"):
+            handler.on_tool_start(self._serialized("delete_record"), "id=123", run_id=_run_id())
+
+    def test_error_message_contains_actor_and_regulation(self) -> None:
+        handler = self._make_handler(
+            allowed_actions={"safe_tool"},
+            regulation="HIPAA",
+            actor_id="nurse_101",
+        )
+        with pytest.raises(PermissionError) as exc_info:
+            handler.on_tool_start(self._serialized("dangerous_tool"), "", run_id=_run_id())
+        msg = str(exc_info.value)
+        assert "nurse_101" in msg
+        assert "HIPAA" in msg
+        assert "dangerous_tool" in msg
+
+    def test_regulation_and_actor_stored_on_handler(self) -> None:
+        handler = self._make_handler(regulation="GLBA", actor_id="advisor_007")
+        assert handler.regulation == "GLBA"
+        assert handler.actor_id == "advisor_007"
+
+    def test_unknown_tool_denied_when_require_all_allowed(self) -> None:
+        handler = self._make_handler(allowed_actions={"known_tool"})
+        with pytest.raises(PermissionError, match="unknown_action"):
+            handler.on_tool_start(self._serialized("unknown_action"), "", run_id=_run_id())
+
+    def test_on_tool_end_does_not_raise(self) -> None:
+        handler = self._make_handler()
+        handler.on_tool_end("result text", run_id=_run_id())
+
+    def test_on_tool_error_does_not_raise(self) -> None:
+        handler = self._make_handler()
+        handler.on_tool_error(RuntimeError("tool failed"), run_id=_run_id())
+
+    def test_custom_tool_name_field(self) -> None:
+        policy = ActionPolicy(allowed_actions={"search_catalog"})
+        handler = GovernanceCallbackHandler(
+            policy=policy,
+            tool_name_field="tool_name",
+        )
+        # Using custom field name — should work
+        handler.on_tool_start({"tool_name": "search_catalog", "description": "..."}, "", run_id=_run_id())
+
+    def test_missing_tool_name_falls_back_to_unknown(self) -> None:
+        """When serialized dict has no name field, 'unknown_tool' is used."""
+        policy = ActionPolicy(allowed_actions={"search_catalog"})
+        handler = GovernanceCallbackHandler(policy=policy)
+        with pytest.raises(PermissionError, match="unknown_tool"):
+            handler.on_tool_start({}, "", run_id=_run_id())
+
+    def test_audit_sink_called_for_permitted_tool(self) -> None:
+        audit_log: list[GovernanceAuditRecord] = []
+        handler = self._make_handler(
+            allowed_actions={"search_catalog"},
+            audit_sink=audit_log.append,
+        )
+        handler.on_tool_start(self._serialized("search_catalog"), "q", run_id=_run_id())
+        assert len(audit_log) == 1
+        assert audit_log[0].permitted is True
+
+    def test_audit_sink_called_for_denied_tool(self) -> None:
+        audit_log: list[GovernanceAuditRecord] = []
+        handler = self._make_handler(
+            allowed_actions={"safe"},
+            audit_sink=audit_log.append,
+        )
+        with pytest.raises(PermissionError):
+            handler.on_tool_start(self._serialized("dangerous"), "arg", run_id=_run_id())
+        assert len(audit_log) == 1
+        assert audit_log[0].permitted is False
+        assert audit_log[0].action_name == "dangerous"
+
+    def test_audit_sink_not_called_when_none(self) -> None:
+        """No error when audit_sink is None."""
+        handler = self._make_handler(allowed_actions={"safe"}, audit_sink=None)
+        handler.on_tool_start(self._serialized("safe"), "", run_id=_run_id())
+
+    def test_escalated_tool_blocked_when_block_on_escalation_true(self) -> None:
+        rule = EscalationRule(
+            condition="export_attempt",
+            action_pattern="export",
+            escalate_to="compliance_officer",
+        )
+        handler = self._make_handler(
+            allowed_actions={"export_report"},
+            escalation_rules=[rule],
+            block_on_escalation=True,
+        )
+        with pytest.raises(PermissionError):
+            handler.on_tool_start(self._serialized("export_report"), "", run_id=_run_id())
+
+    def test_multiple_tools_independent_decisions(self) -> None:
+        handler = self._make_handler(allowed_actions={"tool_a", "tool_b"})
+        # Both should succeed
+        handler.on_tool_start(self._serialized("tool_a"), "", run_id=_run_id())
+        handler.on_tool_start(self._serialized("tool_b"), "", run_id=_run_id())
+        # Third should fail
+        with pytest.raises(PermissionError):
+            handler.on_tool_start(self._serialized("tool_c"), "", run_id=_run_id())
+
+    def test_multiple_permitted_calls_accumulate_audit_records(self) -> None:
+        audit_log: list[GovernanceAuditRecord] = []
+        handler = self._make_handler(
+            allowed_actions={"tool_a", "tool_b"},
+            audit_sink=audit_log.append,
+        )
+        handler.on_tool_start(self._serialized("tool_a"), "", run_id=_run_id())
+        handler.on_tool_start(self._serialized("tool_b"), "", run_id=_run_id())
+        assert len(audit_log) == 2
+        assert {r.action_name for r in audit_log} == {"tool_a", "tool_b"}

--- a/tests/test_regulations.py
+++ b/tests/test_regulations.py
@@ -93,9 +93,7 @@ class TestHIPAATreatingProviderPolicy:
         assert permitted is False
 
     def test_escalates_external_share(self):
-        policy = make_hipaa_treating_provider_policy(
-            escalate_external_share_to="hipaa_privacy_officer"
-        )
+        policy = make_hipaa_treating_provider_policy(escalate_external_share_to="hipaa_privacy_officer")
         result = policy.escalation_for("share_records_externally", {})
         assert result is not None
         assert result.escalate_to == "hipaa_privacy_officer"
@@ -126,16 +124,12 @@ class TestHIPAAResearcherPolicy:
         assert permitted is True
 
     def test_denies_phi_export(self):
-        policy = make_hipaa_researcher_policy(
-            irb_approved_categories={"read_lab_results"}
-        )
+        policy = make_hipaa_researcher_policy(irb_approved_categories={"read_lab_results"})
         permitted, _ = policy.permits("export_phi")
         assert permitted is False
 
     def test_denies_clinical_note_creation(self):
-        policy = make_hipaa_researcher_policy(
-            irb_approved_categories={"read_lab_results"}
-        )
+        policy = make_hipaa_researcher_policy(irb_approved_categories={"read_lab_results"})
         permitted, _ = policy.permits("create_clinical_note")
         assert permitted is False
 


### PR DESCRIPTION
## Summary

- Extends `src/regulated_ai_governance/integrations/langchain.py` with a new `GovernanceCallbackHandler` class that implements the "policy-before-execution" principle (ADR-0001): intercepts LangChain `on_tool_start` synchronously and evaluates every tool invocation against an `ActionPolicy` before the tool function can execute
  - Supports `allowed_actions`, `denied_actions`, `escalation_rules`, and `block_on_escalation` via the existing `GovernedActionGuard` backend
  - Emits `GovernanceAuditRecord` to an optional `audit_sink` for every tool invocation (permitted or denied) — satisfies record-keeping requirements across FERPA § 99.32, HIPAA § 164.312(b), GLBA § 314.4(e)
  - Raises `PermissionError` with actor/regulation/reason context for denied tools
  - Adds `regulation` and `actor_id` as public attributes for inspection
- Updates module docstring to document both handlers with usage examples
- Adds `tests/test_langchain_integration.py` — 31 tests covering:
  - `FERPAComplianceCallbackHandler`: identity filtering, category filtering, raise_on_empty, audit sink, custom field names, document count in audit context
  - `GovernanceCallbackHandler`: permitted/denied/escalated tools, audit records, custom tool_name_field, no-op handlers, multi-call accumulation
  - All tests pass without `langchain-core` installed (sys.modules mock at import time)

## Test plan
- [ ] `pip install -e ".[dev]" && python -m pytest tests/test_langchain_integration.py -v` — 31 tests pass
- [ ] `python -m pytest tests/ -q` — full suite (146 tests) passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)