### PR TITLE
fix: correct import path in test_google_adk_adapter

### DIFF
--- a/tests/test_google_adk_adapter.py
+++ b/tests/test_google_adk_adapter.py
@@ -28,18 +28,11 @@ Run:
 from __future__ import annotations
 
 import json
-import os
-import sys
 from unittest.mock import MagicMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Ensure the adapter is importable from tests/
-# ---------------------------------------------------------------------------
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
-from adapter.google_adk_adapter import (
+from regulated_ai_governance.adapters.google_adk_adapter import (
     ADKMultiAgentGovernance,
     ADKPolicyGuard,
     AuditRecord,


### PR DESCRIPTION
## Summary
The test file was importing from `adapter.google_adk_adapter` (a standalone module path from the pre-integration draft). The adapter now lives at `regulated_ai_governance.adapters.google_adk_adapter`. This fixes the `ModuleNotFoundError` that caused all three Python version test jobs to fail.

Also removed now-unused `os` and `sys` imports that were only needed for the old `sys.path.insert` hack.

## Test plan
- [ ] All 3 Python version test jobs pass
- [ ] Lint job passes